### PR TITLE
Transaction support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,7 +37,7 @@ go_test(
 genrule(
     name = "dynamodb",
     outs = ["dynamodb-local-run-id"],
-    cmd = "docker stop dynamodb-local || true; docker rm -f dynamodb-local || true; docker run -d -p 4569:8000 --name dynamodb-local amazon/dynamodb-local:latest > $@",
+    cmd = "docker stop dynamodb-local || true; docker rm -f dynamodb-local || true; docker run -d -p 4569:8000 --name dynamodb-local amazon/dynamodb-local:1.11.475 > $@",
     local = 1,
     message = "Spinning up dynamo-db container...",
     visibility = ["//visibility:public"],

--- a/BUILD
+++ b/BUILD
@@ -36,9 +36,9 @@ go_test(
 #### Atlassian / Localstack ####
 genrule(
     name = "dynamodb",
-    outs = ["localstack-run-id"],
-    cmd = "docker stop localstack || true; docker rm -f localstack || true; docker run -d -p 4567-4576:4567-4576 --name localstack atlassianlabs/localstack:0.4.1 > $@",
+    outs = ["dynamodb-local-run-id"],
+    cmd = "docker stop dynamodb-local || true; docker rm -f dynamodb-local || true; docker run -d -p 4569:8000 --name dynamodb-local amazon/dynamodb-local:latest > $@",
     local = 1,
-    message = "Spinning up localstack container...",
+    message = "Spinning up dynamo-db container...",
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ go_repository(
 go_repository(
     name = "com_github_stretchr_testify",
     importpath="github.com/stretchr/testify",
-    commit="f6abca593680b2315d2075e0f5e2a9751e3f431a"
+    tag = "v1.2.2"
 )
 go_repository(
     name = "com_github_go_ini_ini",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,12 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.12.0"
+    tag = "0.15.8"
 )
 git_repository(
     name = "bazel_gazelle",
     remote = "https://github.com/bazelbuild/bazel-gazelle.git",
-    tag = "0.12.0",
+    tag = "0.15.0",
 )
 load(
     "@io_bazel_rules_go//go:def.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,12 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.15.8"
+    tag = "0.12.0"
 )
 git_repository(
     name = "bazel_gazelle",
     remote = "https://github.com/bazelbuild/bazel-gazelle.git",
-    tag = "0.15.0",
+    tag = "0.12.0",
 )
 load(
     "@io_bazel_rules_go//go:def.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,7 @@ gazelle_dependencies()
 go_repository(
     name = "com_github_aws_aws_sdk_go",
     importpath="github.com/aws/aws-sdk-go",
-    commit="v1.8.16"
+    commit="v1.16.4"
 )
 go_repository(
     name = "com_github_stretchr_testify",

--- a/domino.go
+++ b/domino.go
@@ -24,6 +24,8 @@ type DynamoDBIFace interface {
 	UpdateItemWithContext(aws.Context, *dynamodb.UpdateItemInput, ...request.Option) (*dynamodb.UpdateItemOutput, error)
 	DeleteItemWithContext(aws.Context, *dynamodb.DeleteItemInput, ...request.Option) (*dynamodb.DeleteItemOutput, error)
 	BatchWriteItemWithContext(aws.Context, *dynamodb.BatchWriteItemInput, ...request.Option) (*dynamodb.BatchWriteItemOutput, error)
+	TransactGetItemsWithContext(aws.Context, *dynamodb.TransactGetItemsInput, ...request.Option) (*dynamodb.TransactGetItemsOutput, error)
+	TransactWriteItemsWithContext(aws.Context, *dynamodb.TransactWriteItemsInput, ...request.Option) (*dynamodb.TransactWriteItemsOutput, error)
 }
 
 type DynamoDBValue map[string]*dynamodb.AttributeValue

--- a/domino_test.go
+++ b/domino_test.go
@@ -292,10 +292,9 @@ func TestBatchGetItem(t *testing.T) {
 	assert.NoError(t, berr)
 	assert.Equal(t, 20, len(b))
 
-	/* TODO: Once dynamodb-local has transaction support, uncomment the following: */
-	// err = tg.ExecuteWith(ctx, db).Results(nextItem)
-	// assert.NoError(t, err)
-	// assert.Equal(t, len(users), 198)
+	err = tg.ExecuteWith(ctx, db).Results(nextItem)
+	assert.NoError(t, err)
+	assert.Equal(t, len(users), 198)
 
 }
 
@@ -502,7 +501,7 @@ func TestTransactWriteItems(t *testing.T) {
 		}
 	}
 
-	// TODO: Run this against live instance once dynamodb-local has transaction support
+	
 
 }
 

--- a/domino_test.go
+++ b/domino_test.go
@@ -543,8 +543,6 @@ func TestExpressions(t *testing.T) {
 	expectedFilter := "registrationDate = :filter_1 OR contains(lastName,:filter_2) OR (NOT registrationDate = :filter_3) OR (size(visits) <=:filter_4 AND size(firstName) >=:filter_5) OR registrationDate = :filter_6 OR registrationDate <= :filter_7 OR (registrationDate between :filter_8 and :filter_9) OR (registrationDate in (:filter_10,:filter_11))"
 	assert.Equal(t, expectedFilter, *q.Build().FilterExpression)
 
-	// fmt.Println(*q.Build())
-
 	channel := make(chan *User)
 	errChan := q.ExecuteWith(ctx, db).StreamWithChannel(channel)
 


### PR DESCRIPTION
Adds transaction support via two new functions added to the go-sdk:
https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#DynamoDB.TransactGetItemsWithContext

https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/#DynamoDB.TransactWriteItemsWithContext

